### PR TITLE
Still away

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -16,8 +16,8 @@ export default function Home() {
     },
     {
       imageUrl:
-        "https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/PAUSE-Retreat-Flier-v2.png",
-      landingPageUrl: "/retreat",
+        "https://wellcall-app-cdk.s3.us-east-1.amazonaws.com/r3counseling/retreat/still-away-flyer.PNG",
+      landingPageUrl: "/retreat/still-away",
     },
   ];
 
@@ -74,9 +74,9 @@ export default function Home() {
         </div>
       </div>
 
-      <h1>PAUSE Boutique Holistic Healing Retreats</h1>
+      <h1>Still Away Boutique Holistic Healing Retreats</h1>
       <p>
-        PAUSE: Holistic Healing retreats for high achieving women to rest,
+        Still Away: Holistic Healing retreats for women to rest,
         restore, and reclaim their wholeness, time, and self care. You may find
         yourself feeling burnt-out, with little time to pour into yourself. The
         daily grind can be overwhelming, leaving little time for self care,

--- a/src/pages/retreat/index.tsx
+++ b/src/pages/retreat/index.tsx
@@ -54,7 +54,9 @@ export default function Retreat() {
         <ul>
           <li>
             <a href="/retreat/still-away" className="new-retreat">
-              Still Away Retreat (New!)
+              <h4>
+              Still Away Retreat (New 2025!)
+              </h4>
             </a>
           </li>
           <li>

--- a/src/pages/retreat/retreat.css
+++ b/src/pages/retreat/retreat.css
@@ -74,6 +74,7 @@
 .image-side img {
   width: 100%; /* Make image fill its container */
   height: auto; /* Keep image aspect ratio */
+  max-height: 60vh; /* Limit image height */
 }
 
 .image-side a {
@@ -122,6 +123,10 @@
   font-size: 16px;
   font-weight: 400;
   font-style: italic;
+}
+
+.banner-container img {
+  margin: 0px 10vw;
 }
 
 /* Responsive adjustments */

--- a/src/pages/retreat/retreat.css
+++ b/src/pages/retreat/retreat.css
@@ -125,7 +125,7 @@
   font-style: italic;
 }
 
-.banner-container img {
+.still-away-banner-container img {
   margin: 0px 10vw;
 }
 

--- a/src/pages/retreat/still-away.tsx
+++ b/src/pages/retreat/still-away.tsx
@@ -62,7 +62,7 @@ export default function StillAwayRetreat() {
             <p className="transition-text">
               Still Away Holistic Healing retreat is for women to rest, restore,
               and reclaim their wholeness, time, and self care. We understand
-              that you are a high achieving woman, constantly juggling the
+              that you are a woman, constantly juggling the
               demands of family, career, and life. You may find yourself feeling
               burnt-out, with little time to pour into yourself. The daily grind
               can be overwhelming, leaving little time for self care,
@@ -123,7 +123,7 @@ export default function StillAwayRetreat() {
                 Onsite breakfast, lunch, and snacks included
               </li>
               <li className="transition-text">
-                All Holistic Healing practices and activities-Trauma Conscious
+                All Holistic Healing practices and activities -
                 Yoga, Sound Meditation, Breath Work, Sister Circles, Still Away
                 Goodie Bag
               </li>
@@ -198,7 +198,7 @@ export default function StillAwayRetreat() {
         </div>
 
         <div className="banner">
-          <div className="banner-container">
+          <div className="still-away-banner-container">
             <img
               src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg"
               className="banner-img"

--- a/src/pages/retreat/still-away.tsx
+++ b/src/pages/retreat/still-away.tsx
@@ -3,6 +3,10 @@ import "./retreat.css";
 
 export default function StillAwayRetreat() {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const url = "https://book.stripe.com/8wMdUfc977kq6t2bIT";
+  const qrCodeUrl = `https://quickchart.io/qr?text=${encodeURIComponent(
+    url
+  )}&size=50&dark=000000&light=ffffff&ecLevel=H&format=png&margin=10&style=square&corner_radius=10`;
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -50,30 +54,44 @@ export default function StillAwayRetreat() {
         <div className="hero-text">Rest. Restore. Reclaim.</div>
       </div>
       <div ref={containerRef}>
-        <h1 className="transition-text">
-          Still Away Holistic Healing Day Retreat
-        </h1>
-        <p className="transition-text">
-          Still Away Holistic Healing retreat is for women to
-          rest, restore, and reclaim their wholeness, time, and self care. We
-          understand that you are a high achieving woman, constantly juggling
-          the demands of family, career, and life. You may find yourself feeling
-          burnt-out, with little time to pour into yourself. The daily grind can
-          be overwhelming, leaving little time for self care, authenticity, and
-          rejuvenation. It is time to reset, recenter, and cultivate the balance
-          you have envisioned. During this day retreat we will, awaken your
-          innate need to care for yourself, begin to restore yourself, while
-          surrounded by safe and supportive community. It is okay to give
-          yourself permission to Still Away.
-        </p>
-        {/* <div className="container"> */}
-        <div className="coming-soon-container">
-          <h2 className="transition-text">
-            Still Away Day Retreat is for the women
-          </h2>
-        </div>
         <div className="container">
           <div className="text-side">
+            <h1 className="transition-text">
+              Still Away Holistic Healing Day Retreat
+            </h1>
+            <p className="transition-text">
+              Still Away Holistic Healing retreat is for women to rest, restore,
+              and reclaim their wholeness, time, and self care. We understand
+              that you are a high achieving woman, constantly juggling the
+              demands of family, career, and life. You may find yourself feeling
+              burnt-out, with little time to pour into yourself. The daily grind
+              can be overwhelming, leaving little time for self care,
+              authenticity, and rejuvenation. It is time to reset, recenter, and
+              cultivate the balance you have envisioned. During this day retreat
+              we will, awaken your innate need to care for yourself, begin to
+              restore yourself, while surrounded by safe and supportive
+              community. It is okay to give yourself permission to Still Away.
+            </p>
+          </div>
+        </div>
+        <div className="container">
+          <div className="image-side">
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg"
+            />
+            <a
+              href="https://book.stripe.com/8wMdUfc977kq6t2bIT"
+              target="_blank"
+            >
+              <button title="Join Retreat">Join Retreat</button>
+            </a>
+          </div>
+          <div className="text-side">
+            <div className="coming-soon-container text-side">
+              <h2 className="transition-text">
+                Still Away Day Retreat is for the women
+              </h2>
+            </div>
             <ul className="transition-text">
               <li className="transition-text">
                 Who are with limited time for self
@@ -93,108 +111,156 @@ export default function StillAwayRetreat() {
                 Who are ready to take time to come back to themselves
               </li>
             </ul>
-            <div className="container">
-              <div className="text-side">
-                <h3 className="transition-text">Still Away Includes:</h3>
-                <ul className="transition-text">
-                  <li className="transition-text">
-                    Day accommodations on 18 acres of serene property, including
-                    indoor/outdoor living space, jacuzzi, fire pit, walking
-                    paths, pond, and lake access
-                  </li>
-                  <li className="transition-text">
-                    Onsite breakfast, lunch, and snacks included
-                  </li>
-                  <li className="transition-text">
-                    All Holistic Healing practices and activities-Trauma
-                    Conscious Yoga, Sound Meditation, Breath Work, Sister
-                    Circles, Still Away Goodie Bag
-                  </li>
-                  <li className="transition-text">Bonuses: Express Facials and</li>
-                </ul>
 
-                <h3 className="transition-text">Sample Retreat Schedule:</h3>
-                <ul className="transition-text">
-                  <li className="transition-text">
-                    8:00 AM - Arrival and Welcome
-                  </li>
-                  <li className="transition-text">
-                    9:00 AM - Yoga
-                  </li>
-                  <li className="transition-text">
-                    10:30 AM - Sound Meditation
-                  </li>
-                  <li className="transition-text">12:00 PM - Lunch</li>
-                  <li className="transition-text">1:00 PM - Breath Work</li>
-                  <li className="transition-text">2:30 PM - Sister Circles</li>
-                  <li className="transition-text">4:00 PM - Free Time</li>
-                  <li className="transition-text">5:00 PM - Closing Circle</li>
-                </ul>
-              </div>
-              <div className="image-side" style={{ height: "60vh" }}>
-                <img
-                  src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg"
-                  style={{
-                    height: "100%",
-                    width: "100%",
-                    objectFit: "contain",
-                  }}
-                />
-              </div>
-            </div>
-            <div className="container">
-              <div className="image-side" style={{ height: "40vh" }}>
-                <img
-                  src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-flower.jpeg"
-                  style={{
-                    height: "100%",
-                    width: "100%",
-                    objectFit: "contain",
-                  }}
-                />
-              </div>
-              <div className="text-side">
-                <h3 className="transition-text">Cost:</h3>
-                <p className="transition-text">$347 per person</p>
-                <h3 className="transition-text">Payment:</h3>
-                <p className="transition-text">
-                  Payment can be made via credit card or Stripe.
-                </p>
-              </div>
-              <div className="image-side" style={{ height: "40vh" }}>
-                <img
-                  src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-stripe-qr.png"
-                  style={{
-                    height: "100%",
-                    width: "100%",
-                    objectFit: "contain",
-                  }}
-                />
-              </div>
-            </div>
-            <h3 className="transition-text">Frequently Asked Questions:</h3>
+            <h3 className="transition-text">Still Away Includes:</h3>
             <ul className="transition-text">
               <li className="transition-text">
-                <strong>What is the location of the retreat?</strong> Appling,
-                GA 30802. Address will be provided to the email address used at
-                booking.
+                Day accommodations on 18 acres of serene property, including
+                indoor/outdoor living space, jacuzzi, fire pit, walking paths,
+                pond, and lake access
               </li>
               <li className="transition-text">
-                <strong>Is parking available?</strong> Yes, parking is available
-                on-site. No cost.
+                Onsite breakfast, lunch, and snacks included
               </li>
               <li className="transition-text">
-                <strong>Can I bring swimwear for the jacuzzi?</strong> Of
-                course!! You will have access to private bedrooms and bathrooms,
-                if needed to change your clothing.
+                All Holistic Healing practices and activities-Trauma Conscious
+                Yoga, Sound Meditation, Breath Work, Sister Circles, Still Away
+                Goodie Bag
               </li>
               <li className="transition-text">
-                <strong>What should I bring?</strong> Yoga mat, swim wear (if
-                you desire), comfy shoes, a cozy blanket.
+                Bonuses: Express Facials and Speedy Hydration and Wellness
+                Ocygen Therapy
               </li>
             </ul>
           </div>
         </div>
+        <div>
+          <h1 className="transition-text">
+            Sample Retreat Schedule &quot;Schedule is Subject to Change&quot;
+          </h1>
+        </div>
+        <div className="container">
+          <div className="text-side">
+            <h5 className="transition-text">Arrive & Awaken</h5>
+            <div>
+              <ul className="transition-text">
+                <li className="transition-text">Welcome</li>
+                <li className="transition-text">Intention Setting</li>
+                <li className="transition-text">Breakfast</li>
+              </ul>
+            </div>
+
+            <h5 className="transition-text">Restore & Connect</h5>
+            <div>
+              <ul className="transition-text">
+                <li className="transition-text">Yoga</li>
+                <li className="transition-text">Sound Meditation</li>
+                <li className="transition-text">Sister Circle</li>
+              </ul>
+            </div>
+
+            <h5 className="transition-text">Nourish & Rejuvenate</h5>
+            <div>
+              <ul className="transition-text">
+                <li className="transition-text">Lunch</li>
+                <li className="transition-text">Relax</li>
+                <li className="transition-text">
+                  Individual Breakout Sessions: Facials and Oxygen Therapy
+                </li>
+              </ul>
+            </div>
+
+            <h5 className="transition-text">Reflect & Renew</h5>
+            <div>
+              <ul className="transition-text">
+                <li className="transition-text">Sister Circle Activity</li>
+                <li className="transition-text">Closing Reflection</li>
+                <li className="transition-text">Farewell</li>
+              </ul>
+            </div>
+          </div>
+          <div className="image-side">
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-patio.jpeg"
+              style={{
+                height: "100%",
+                width: "100%",
+                objectFit: "contain",
+              }}
+            />
+            <a
+              href="https://book.stripe.com/8wMdUfc977kq6t2bIT"
+              target="_blank"
+            >
+              <button title="Join Retreat">Join Retreat</button>
+            </a>
+          </div>
+        </div>
+
+        <div className="banner">
+          <div className="banner-container">
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg"
+              className="banner-img"
+            />
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-flower.jpeg"
+              className="banner-img"
+            />
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-patio.jpeg"
+              className="banner-img"
+            />
+          </div>
+        </div>
+        
+        <div className="container">
+          <div className="image-side">
+            <img
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-backyard.png"
+              style={{
+                height: "100%",
+                width: "100%",
+                objectFit: "contain",
+              }}
+            />
+            <a
+              href="https://book.stripe.com/8wMdUfc977kq6t2bIT"
+              target="_blank"
+            >
+              <button title="Join Retreat">Join Retreat</button>
+            </a>
+          </div>
+          <div className="text-side">
+            <h3 className="transition-text">Cost:</h3>
+            <p className="transition-text">$357 per person</p>
+            <h3 className="transition-text">Payment:</h3>
+            <p className="transition-text">
+              Payment can be made via credit card or Apple Pay via Stripe.
+            </p>
+          </div>
+        </div>
+        <h3 className="transition-text">Frequently Asked Questions:</h3>
+        <ul className="transition-text">
+          <li className="transition-text">
+            <strong>What is the location of the retreat?</strong> Appling, GA
+            30802. Address will be provided to the email address used at
+            booking.
+          </li>
+          <li className="transition-text">
+            <strong>Is parking available?</strong> Yes, parking is available
+            on-site. No cost.
+          </li>
+          <li className="transition-text">
+            <strong>Can I bring swimwear for the jacuzzi?</strong> Of course!!
+            You will have access to private bedrooms and bathrooms, if needed to
+            change your clothing.
+          </li>
+          <li className="transition-text">
+            <strong>What should I bring?</strong> Yoga mat, swim wear (if you
+            desire), comfy shoes, a cozy blanket.
+          </li>
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request includes several changes to the `src/pages/home/index.tsx`, `src/pages/retreat/index.tsx`, `src/pages/retreat/retreat.css`, and `src/pages/retreat/still-away.tsx` files. The updates primarily focus on rebranding the retreat and enhancing the retreat page with new content and styling.

Rebranding updates:

* Updated image URLs and landing page URL for the retreat in `Home` component.
* Changed the retreat name from "PAUSE" to "Still Away" in the `Home` component.
* Updated the retreat name and added "New 2025!" label in the `Retreat` component.

Content and styling enhancements:

* Added a new QR code URL and updated the retreat description in the `StillAwayRetreat` component. [[1]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717R6-R9) [[2]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717R57-L76)
* Enhanced the retreat schedule and added new activities in the `StillAwayRetreat` component.
* Added new CSS rules to improve the layout and styling of the retreat page, including limiting image height and adding margins to images in the banner container. [[1]](diffhunk://#diff-30057c37e79fcebd4463c1dca2c249a8d0874f97b97f65c40ed50fb85ce74c32R77) [[2]](diffhunk://#diff-30057c37e79fcebd4463c1dca2c249a8d0874f97b97f65c40ed50fb85ce74c32R128-R131)