### PR TITLE
FONT ✏️

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -178,15 +178,16 @@ button:disabled {
 h4,
 h2,
 h3,
-h5 {
+h5,
+h1 {
   color: #839abf;
   font-family: LucidaHandwriting;
 }
 
-h1 {
+/* h1 {
   color: #839abf;
   font-family: BradleysPen;
-}
+} */
 
 .App-footer {
   background: linear-gradient(-45deg, #d3fbf7, #fbdcd3, #fbf0d3);

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -74,9 +74,9 @@ export default function Home() {
         </div>
       </div>
 
-      <h1>Still Away Boutique Holistic Healing Retreats</h1>
+      <h1>Boutique Holistic Healing Retreats</h1>
       <p>
-        Still Away: Holistic Healing retreats for women to rest, restore, and
+        Holistic Healing retreats for women to rest, restore, and
         reclaim their wholeness, time, and self care. You may find yourself
         feeling burnt-out, with little time to pour into yourself. The daily
         grind can be overwhelming, leaving little time for self care,

--- a/src/pages/retreat/index.tsx
+++ b/src/pages/retreat/index.tsx
@@ -74,7 +74,7 @@ export default function Retreat() {
           <h1 className="transition-text">Your Host</h1>
           <p className="transition-text">
             Hey Y’all, I‘m Tiffany. I am an ambitous woman juggling the roles of
-            a devoted wife, a nurturing mother to three amazing kiddos, and a
+            a wife, a nurturing mother to three amazing kiddos, and a
             multipreneur. For years, I threw myself into caring for others,
             often neglecting my own well-being in the process. Despite my
             dedication, I began feeling drained, disconnected, and even

--- a/src/pages/retreat/retreat.css
+++ b/src/pages/retreat/retreat.css
@@ -116,7 +116,7 @@
   text-align: center;
   background-color: rgba(0, 0, 0, 0.1); /* Semi-transparent background */
   padding: 20px;
-  font-family: BradleysPen;
+  font-family: LucidaHandwriting;
 }
 
 .banner-container {

--- a/src/pages/retreat/still-away.tsx
+++ b/src/pages/retreat/still-away.tsx
@@ -126,7 +126,7 @@ export default function StillAwayRetreat() {
               </li>
               <li className="transition-text">
                 Bonuses: Express Facials and Speedy Hydration and Wellness
-                Ocygen Therapy
+                Oxygen Therapy
               </li>
             </ul>
           </div>


### PR DESCRIPTION
This pull request includes changes to the styling and content of several pages in the application. The most important changes involve updates to text content, font styles, and a minor correction in a list item.

Content updates:

* [`src/pages/home/index.tsx`](diffhunk://#diff-1a85353fd4d626d682cda43134eb77c90569657758fe3e0a8be1c4c5dd7b07a4L77-R79): Updated the heading and paragraph text to remove the phrase "Still Away" from the boutique holistic healing retreats description.
* [`src/pages/retreat/index.tsx`](diffhunk://#diff-3875af29757d7f2a4efd3314685bca82a67854ba5937d75f25d67d9e57715573L77-R77): Modified the text in the "Your Host" section to simplify the description of the host's roles.

Styling updates:

* [`src/App.css`](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L181-R190): Added `h1` to the list of elements with the same color and font-family styling and commented out the previous `h1` styling.
* [`src/pages/retreat/retreat.css`](diffhunk://#diff-30057c37e79fcebd4463c1dca2c249a8d0874f97b97f65c40ed50fb85ce74c32L119-R119): Changed the font-family of a specific section from `BradleysPen` to `LucidaHandwriting`.

Minor corrections:

* [`src/pages/retreat/still-away.tsx`](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L129-R129): Corrected the spelling of "Ocygen Therapy" to "Oxygen Therapy" in the list of bonuses.