### PR TITLE
mix-up fix

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -16,7 +16,7 @@ export default function Home() {
     },
     {
       imageUrl:
-        "https://wellcall-app-cdk.s3.us-east-1.amazonaws.com/r3counseling/retreat/still-away-flyer.PNG",
+        "https://wellcall-app-cdk.s3.us-east-1.amazonaws.com/r3counseling/retreat/still-away-lake-sinclair-flyer.png",
       landingPageUrl: "/retreat/still-away",
     },
   ];
@@ -76,12 +76,12 @@ export default function Home() {
 
       <h1>Boutique Holistic Healing Retreats</h1>
       <p>
-        Holistic Healing retreats for women to rest, restore, and
-        reclaim their wholeness, time, and self care. You may find yourself
-        feeling burnt-out, with little time to pour into yourself. The daily
-        grind can be overwhelming, leaving little time for self care,
-        authenticity, and rejuvenation. It is time to reset, recenter, and
-        cultivate the balance you have envisioned.
+        Holistic Healing retreats for women to rest, restore, and reclaim their
+        wholeness, time, and self care. You may find yourself feeling burnt-out,
+        with little time to pour into yourself. The daily grind can be
+        overwhelming, leaving little time for self care, authenticity, and
+        rejuvenation. It is time to reset, recenter, and cultivate the balance
+        you have envisioned.
       </p>
       <div className="banner">
         <div className="banner-container">

--- a/src/pages/retreat/still-away.tsx
+++ b/src/pages/retreat/still-away.tsx
@@ -76,7 +76,7 @@ export default function StillAwayRetreat() {
         </div>
         <div className="container">
           <div className="image-side">
-            <img src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg" />
+            <img src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-lake.jpg" />
             <a
               href="https://book.stripe.com/8wMdUfc977kq6t2bIT"
               target="_blank"
@@ -113,9 +113,8 @@ export default function StillAwayRetreat() {
             <h3 className="transition-text">Still Away Includes:</h3>
             <ul className="transition-text">
               <li className="transition-text">
-                Day accommodations on 18 acres of serene property, including
-                indoor/outdoor living space, jacuzzi, fire pit, walking paths,
-                pond, and lake access
+                Day accommodations on serene property, including indoor/outdoor
+                living space, jacuzzi, fire pit, walking paths, and lake access
               </li>
               <li className="transition-text">
                 Onsite breakfast, lunch, and snacks included
@@ -178,7 +177,7 @@ export default function StillAwayRetreat() {
           </div>
           <div className="image-side">
             <img
-              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-patio.jpeg"
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-dock.jpg"
               style={{
                 height: "100%",
                 width: "100%",
@@ -197,7 +196,7 @@ export default function StillAwayRetreat() {
         <div className="banner">
           <div className="banner-container">
             <img
-              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-porch.jpeg"
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-lake.jpg"
               className="banner-img"
             />
             <img
@@ -213,7 +212,7 @@ export default function StillAwayRetreat() {
               className="banner-img"
             />
             <img
-              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-patio.jpeg"
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-dock.jpg"
               className="banner-img"
             />
           </div>
@@ -222,7 +221,7 @@ export default function StillAwayRetreat() {
         <div className="container">
           <div className="image-side">
             <img
-              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-backyard.png"
+              src="https://wellcall-app-cdk.s3.amazonaws.com/r3counseling/retreat/still-away-hot-tub.jpg"
               style={{
                 height: "100%",
                 width: "100%",
@@ -248,8 +247,8 @@ export default function StillAwayRetreat() {
         <h3 className="transition-text">Frequently Asked Questions:</h3>
         <ul className="transition-text">
           <li className="transition-text">
-            <strong>What is the location of the retreat?</strong> Appling, GA
-            30802. Address will be provided to the email address used at
+            <strong>What is the location of the retreat?</strong> Lake Sinclair,
+            Eatonton, GA. Address will be provided to the email address used at
             booking.
           </li>
           <li className="transition-text">


### PR DESCRIPTION
This pull request includes updates to image URLs and text content for the "Home" and "Still Away Retreat" pages. The changes primarily involve updating image links to reflect new images and making minor text adjustments for better readability.

### Updates to image URLs:

* Updated the image URL for the retreat flyer in `src/pages/home/index.tsx`.
* Updated multiple image URLs in `src/pages/retreat/still-away.tsx` to reflect new images of the retreat. [[1]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L79-R79) [[2]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L181-R180) [[3]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L200-R199) [[4]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L216-R215) [[5]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L225-R224)

### Text content adjustments:

* Reformatted the paragraph text for better readability in `src/pages/home/index.tsx`.
* Updated the description of day accommodations and the retreat location in `src/pages/retreat/still-away.tsx`. [[1]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L116-R117) [[2]](diffhunk://#diff-be84f8aeb7f9c9b7177ca5cbec1f2ffc5e03e5198eb35d32ce6f5355c12d2717L251-R251)