### PR TITLE
Remove target="_blank" from carousel image links

### DIFF
--- a/src/components/imageCarousel/imageCarousel.tsx
+++ b/src/components/imageCarousel/imageCarousel.tsx
@@ -20,7 +20,7 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className }) => {
 
   return (
     <div>
-      <a href={images[currentIndex].landingPageUrl} target="_blank">
+      <a href={images[currentIndex].landingPageUrl}>
         <img
           className={className}
           src={images[currentIndex].imageUrl}

--- a/src/components/imageCarousel/imageCarousel.tsx
+++ b/src/components/imageCarousel/imageCarousel.tsx
@@ -20,7 +20,7 @@ const ImageCarousel: React.FC<ImageCarouselProps> = ({ images, className }) => {
 
   return (
     <div>
-      <a href={images[currentIndex].landingPageUrl}>
+      <a href={images[currentIndex].landingPageUrl} rel="noopener">
         <img
           className={className}
           src={images[currentIndex].imageUrl}


### PR DESCRIPTION
Updated the image carousel to open image links in the same tab instead of a new tab by removing the target="_blank" attribute from the anchor tag.