### PR TITLE
Add SPA redirect script to index.html for improved URL handling

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -65,26 +65,6 @@
         }
       }
     </style>
-    <script type="text/javascript">
-      // Single Page Apps for GitHub Pages
-      // MIT License
-      // https://github.com/rafgraph/spa-github-pages
-      // This script takes the current url and converts the path and query
-      // string into just a query string, and then redirects the browser
-      // to the new url with only a query string and hash fragment,
-      // e.g. https://r3counseling.com/about becomes
-      // https://r3counseling.com/?p=/about
-      var pathSegmentsToKeep = 0;
-
-      var l = window.location;
-      l.replace(
-        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?p=/' +
-        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-        (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-        l.hash
-      );
-    </script>
   </head>
   <body>
     <div class="container">

--- a/public/index.html
+++ b/public/index.html
@@ -75,6 +75,36 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <!-- Single Page Apps for GitHub Pages -->
+    <!-- MIT License -->
+    <!-- https://github.com/rafgraph/spa-github-pages -->
+    <!-- This script checks to see if a redirect is present in the query string,
+         converts it back into the correct url and adds it to the
+         browser's history using window.history.replaceState(...),
+         which won't cause the browser to attempt to load the new url.
+         When the single page app is loaded further down in this file,
+         the correct url will be waiting in the browser's history for
+         the single page app to route accordingly. -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://r3counseling.com/?p=/about becomes
+      // https://r3counseling.com/about
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
     <!-- Structured Data for LocalBusiness - Important for SEO -->
     <script type="application/ld+json">
       {


### PR DESCRIPTION
This pull request updates the handling of client-side routing for single page applications (SPA) hosted on GitHub Pages. The main change is moving the SPA redirect script from `public/404.html` to `public/index.html`, and updating its logic to improve how URLs are restored for proper routing and browser history management.

**SPA Routing Improvements:**

* Removed the SPA redirect script from `public/404.html`, simplifying the error page and eliminating client-side redirect logic from this file.
* Added an updated SPA redirect script to `public/index.html` that checks for redirect information in the query string, reconstructs the correct URL, and uses `window.history.replaceState` to update the browser's history without triggering a full page reload. This ensures smoother navigation and correct routing for the single page app.