### PR TITLE
Swap Columbia County Amphitheatre and Nature and Nurture event details in events component

### DIFF
--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -26,20 +26,20 @@ export default function Events() {
       <div className="events-row">
         <div
           className="events-col"
-          onClick={() => openModal(NatureAndNurture)}
-        >
-          <img
-            src={NatureAndNurture}
-            alt="Nature and Nurture 2025 wellness retreat and counseling event"
-          />
-        </div>
-        <div
-          className="events-col"
           onClick={() => openModal(ColumbiaCountyAmphitheatre)}
         >
           <img
             src={ColumbiaCountyAmphitheatre}
             alt="Columbia County Amphitheatre mental health awareness event and counseling services"
+          />
+        </div>
+        <div
+          className="events-col"
+          onClick={() => openModal(NatureAndNurture)}
+        >
+          <img
+            src={NatureAndNurture}
+            alt="Nature and Nurture 2025 wellness retreat and counseling event"
           />
         </div>
         <div


### PR DESCRIPTION
This pull request makes a small change to the `Events` page by swapping the order of the "Nature and Nurture" and "Columbia County Amphitheatre" event tiles. The click handlers and images for these two events have been switched to ensure each event displays the correct information and modal when clicked.