### PR TITLE
feat: simplify notification handling to use user's email for notifications

### DIFF
--- a/backend/src/handlers/lead.ts
+++ b/backend/src/handlers/lead.ts
@@ -55,7 +55,7 @@ async function getFromEmail(): Promise<string> {
 
 export const handler = async (event: any) => {
   try {
-    const { name, email, message, captchaToken, notifyTo } = JSON.parse(event.body || "{}");
+    const { name, email, message, captchaToken } = JSON.parse(event.body || "{}");
     
     if (!name || !email) return json(400, { error: "invalid_input" });
 
@@ -65,13 +65,10 @@ export const handler = async (event: any) => {
       return json(400, { error: "invalid_email" });
     }
 
-    // Process notifyTo emails (similar to how the old NOTIFY_TO was processed)
-    const notifyToEmails = notifyTo ? 
-      (typeof notifyTo === 'string' ? notifyTo : String(notifyTo))
-        .split(",")
-        .map(s => s.trim())
-        .filter(Boolean) 
-      : [];
+    // Use the user's email for notifications
+    const notifyToEmails = [email];
+
+    console.log(`Debug - email from payload: ${JSON.stringify(email)}, notifyToEmails: ${JSON.stringify(notifyToEmails)}`);
 
     // Verify captcha if secret is available
     const secret = await getCaptchaSecret();
@@ -139,7 +136,7 @@ export const handler = async (event: any) => {
         // Don't fail the whole request if email fails
       }
     } else {
-      console.log(`Notification email not sent. notifyTo: ${notifyToEmails}`);
+      console.log(`Notification email not sent. email from payload: ${JSON.stringify(email)}, processed emails: ${JSON.stringify(notifyToEmails)}`);
     }
 
     // Send separate message email to admin (Tiff) if message exists and admin email is configured


### PR DESCRIPTION
This pull request simplifies the notification email logic in the `lead.ts` handler by removing the `notifyTo` parameter from the API payload and always using the user's email for notifications. It also updates debug logging to reflect these changes, making the code easier to maintain and debug.

**Notification email logic simplification:**

* Removed the `notifyTo` parameter from the request payload, so notifications are no longer sent to arbitrary email addresses provided by the client. (`backend/src/handlers/lead.ts`)
* Updated the notification email logic to always use the user's email (`email`) for notifications, replacing previous logic that split and processed `notifyTo`. (`backend/src/handlers/lead.ts`)

**Debug logging improvements:**

* Updated debug logs to show the user's email and the processed notification emails, reflecting the new logic and making troubleshooting easier. (`backend/src/handlers/lead.ts`) [[1]](diffhunk://#diff-3db72223a467cfabfa3b63dd2a61c60edeaf6e7981b2f6e5e5a7e794ff101c6fL68-R71) [[2]](diffhunk://#diff-3db72223a467cfabfa3b63dd2a61c60edeaf6e7981b2f6e5e5a7e794ff101c6fL142-R139)