### PR TITLE
Fix frontend CI test by updating App assertion and mocking matchMedia

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import App from "./App";
 
-test("renders learn react link", () => {
+test("renders homepage hero heading", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByRole("heading", {
+    name: /let's come alive/i,
+  });
+  expect(headingElement).toBeInTheDocument();
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,17 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+
+Object.defineProperty(window, "matchMedia", {
+	writable: true,
+	value: (query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: jest.fn(),
+		removeListener: jest.fn(),
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+		dispatchEvent: jest.fn(),
+	}),
+});


### PR DESCRIPTION
This pull request updates the test setup to better support components that rely on browser APIs and improves the main app test to check for the correct homepage heading.

Testing improvements:

* Updated the main app test in `App.test.tsx` to check for the homepage hero heading ("Let's come alive") instead of the default React link, making the test more relevant to the current UI.
* Added a mock implementation of `window.matchMedia` in `setupTests.ts` to ensure compatibility with components using media queries during testing.