### PR TITLE
Fix promotion workflow: CloudFront conditional and backend prod stage

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -98,8 +98,8 @@ jobs:
           role-session-name: r3counseling-backend-deploy-prod
           aws-region: us-east-1
 
-      - name: Deploy to AWS (production workflow, legacy dev stage)
+      - name: Deploy to AWS (production)
         working-directory: ./backend
-        run: npx serverless deploy --stage dev
+        run: npx serverless deploy --stage prod
         env:
           AWS_REGION: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,10 @@ jobs:
         run: aws s3 sync build/ "s3://${{ secrets.FRONTEND_STAGING_S3_BUCKET }}" --delete
 
       - name: Invalidate CloudFront cache (staging)
-        if: ${{ secrets.FRONTEND_STAGING_CLOUDFRONT_DISTRIBUTION_ID != '' }}
-        run: aws cloudfront create-invalidation --distribution-id "${{ secrets.FRONTEND_STAGING_CLOUDFRONT_DISTRIBUTION_ID }}" --paths "/*"
+        env:
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.FRONTEND_STAGING_CLOUDFRONT_DISTRIBUTION_ID }}
+        if: ${{ env.CLOUDFRONT_DISTRIBUTION_ID != '' }}
+        run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"
 
   deploy_production:
     runs-on: ubuntu-latest
@@ -99,5 +101,7 @@ jobs:
         run: aws s3 sync build/ "s3://${{ secrets.FRONTEND_PROD_S3_BUCKET }}" --delete
 
       - name: Invalidate CloudFront cache (production)
-        if: ${{ secrets.FRONTEND_PROD_CLOUDFRONT_DISTRIBUTION_ID != '' }}
-        run: aws cloudfront create-invalidation --distribution-id "${{ secrets.FRONTEND_PROD_CLOUDFRONT_DISTRIBUTION_ID }}" --paths "/*"
+        env:
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.FRONTEND_PROD_CLOUDFRONT_DISTRIBUTION_ID }}
+        if: ${{ env.CLOUDFRONT_DISTRIBUTION_ID != '' }}
+        run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"


### PR DESCRIPTION
## Summary

Two targeted fixes to the GitHub Actions promotion workflows.

### `deploy.yml` — Fix CloudFront cache invalidation conditional
GitHub Actions does not evaluate `secrets.*` in `if:` expressions. The CloudFront invalidation step was silently skipped or erroring because the condition referenced the secret directly. Fixed by assigning the secret to an `env` var and checking `env.CLOUDFRONT_DISTRIBUTION_ID != ''` instead.

### `backend-deploy.yml` — Deploy production to `--stage prod`
The production backend deploy job was using `--stage dev`, which would have overwritten the live production stack instead of deploying to the correct `prod` stage. Corrected to `--stage prod`.

## Required secrets already in place
- `AWS_ROLE_ARN` ✅
- `AWS_STAGING_ROLE_ARN` ✅
- `REACT_APP_API_URL` ✅
- `REACT_APP_API_URL_STAGING` ✅
- `REACT_APP_PUBLIC_URL` ✅
- `REACT_APP_PUBLIC_URL_STAGING` ✅
- `FRONTEND_STAGING_S3_BUCKET` — add value: `r3counseling-frontend-staging`
- `FRONTEND_PROD_S3_BUCKET` — add value: `r3counseling-frontend-prod`