### PR TITLE
Close out June 2026 feedback (rounds 1–3)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 .App {
   text-align: center;
-  font-family: "League Spartan", arial, helvetica, sans-serif;
+  font-family: "Josefin Sans", arial, helvetica, sans-serif;
 }
 
 /* CSS Custom Properties (Variables) */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import {
   BrowserRouter as Router,
   Switch,
   Route,
+  Redirect,
   Link,
   useLocation,
 } from "react-router-dom";
@@ -10,7 +11,6 @@ import "./App.css";
 import { Menu } from "antd";
 import Home from "./pages/home";
 import About from "./pages/about";
-import Terms from "./pages/terms";
 import Offerings from "./pages/offerings";
 import ReadyToRelease from "./pages/ready-to-release";
 import AppointmentRequest from "./pages/appointment-request";
@@ -428,7 +428,7 @@ function App() {
                 <About />
               </Route>
               <Route path="/terms">
-                <Terms />
+                <Redirect to="/ready-to-release" />
               </Route>
               <Route path="/resources">
                 <Resources isMobile={isMobile} />
@@ -443,9 +443,6 @@ function App() {
                 <Contact />
               </Route>
               <Route path="/ready-to-release">
-                <ReadyToRelease />
-              </Route>
-              <Route path="/terms">
                 <ReadyToRelease />
               </Route>
               <Route path="/appointment-request">

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -143,12 +143,6 @@ export default function Events() {
             alt="BIPOC Neurodivergent Support Group virtual event flyer – virtual, 18+, open to anywhere. Sundays 2:00–3:15 PM EDT, July 12 – September 20. $25–$75 sliding scale, pay what you can."
             itemProp="image"
           />
-          <div className="event-details">
-            <p><strong>BIPOC Neurodivergent Support Group</strong></p>
-            <p>Virtual · 18+ · Open to Anywhere</p>
-            <p>Sundays 2:00–3:15 PM EDT · July 12 – September 20</p>
-            <p>$25–$75 Sliding Scale · Pay What You Can</p>
-          </div>
         </article>
         <article
           className="events-col"
@@ -181,13 +175,6 @@ export default function Events() {
             alt="QTBIPOC ADHD Support Group – new session, virtual. Facilitated by Nicole Thoms Fuentes, Associate Licensed Therapist. Wednesdays 6:30–7:45 PM EDT, bi-weekly, August 5 – October 14. $25–$75 per meeting, pay what you can."
             itemProp="image"
           />
-          <div className="event-details">
-            <p><strong>QTBIPOC ADHD Support Group</strong></p>
-            <p>Virtual · 18+ · Open to Anywhere</p>
-            <p>Wednesdays 6:30–7:45 PM EDT · Bi-weekly · Aug 5 – Oct 14</p>
-            <p>Facilitated by Nicole Thoms Fuentes</p>
-            <p>$25–$75 Per Meeting · Pay What You Can</p>
-          </div>
         </article>
         <article
           className="events-col"


### PR DESCRIPTION
## Summary

Closes out all three rounds of June 2026 client feedback for the R3 Counseling website.

---

### Round 3
- **Events page**: Removed duplicate text blocks (event name, schedule, pricing) beneath the BIPOC Neurodivergent Support Group and QTBIPOC ADHD Support Group 2026 flyers. Flyer images, modal lightbox behavior, registration links, and structured data (schema.org) are fully preserved.

### Round 2 (remaining items)
- **Sitewide font**: Updated `.App` in `App.css` from `League Spartan` to `Josefin Sans`, completing the sitewide font rollout already established in `index.css`.
- **Terms/Ready to Release consolidation**: `/terms` now redirects to `/ready-to-release` via React Router `<Redirect>`. Removed the dead duplicate route and the unused `Terms` import from `App.tsx`.

### Round 1
All items were already implemented in prior commits (Tiffany bio/credentials update, Goldman Sachs reference removed, homepage messaging, Practice Leadership banner, CTA placement).

---

### QA Checklist
- [x] Both 2026 event flyer images remain visible
- [x] No duplicate event text beneath flyers
- [x] `/terms` redirects to `/ready-to-release`
- [x] Josefin Sans applied sitewide
- [x] Build passes (`CI=false npm run build`)
