### PR TITLE
Clean up untracked root files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# local working notes, not part of the shipped site
+/notes
+
 # misc
 .DS_Store
 .env


### PR DESCRIPTION
## Summary
- Adds `/notes` to `.gitignore` for local planning/task docs (previously several extension-less files sitting untracked at repo root)
- Deletes two duplicate event flyer PNGs from repo root that were byte-identical to assets already committed under `src/assets/images/2026/` and unreferenced in source

## Validation
- Confirmed the removed PNGs aren't referenced anywhere in `src/` via grep
- `git status` is clean of stray untracked files at repo root after this change
